### PR TITLE
Update version to v0.57.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 OUTPUT_DIR=bin
-OTEL_VERSION=0.57.0
+OTEL_VERSION=0.57.2
 
 IMAGE_NAME=otelcol-custom
 IMAGE_VERSION=latest


### PR DESCRIPTION
Upstream skipped v0.57.1 and v0.57.2, update that here

Fixes https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/issues/3