### PR TITLE
Add Makefile commands for creating and updating otel config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ IMAGE_VERSION=latest
 CONTAINER_REGISTRY=otel-collectors
 REGISTRY_LOCATION=us-central1
 
+OTEL_CONFIG_FILE=./otel-config.yaml
+
 .PHONY: setup
 setup:
 	curl -L -o ${OUTPUT_DIR}/ocb --create-dirs https://github.com/open-telemetry/opentelemetry-collector/releases/download/v${OTEL_VERSION}/ocb_${OTEL_VERSION}_linux_amd64
@@ -48,3 +50,11 @@ cloudbuild-setup:
 .PHONY: cloudbuild
 cloudbuild:
 	gcloud beta builds submit --substitutions=_COLLECTOR_REPO=${CONTAINER_REGISTRY},_COLLECTOR_IMAGE=${IMAGE_NAME}:${IMAGE_VERSION}
+
+.PHONY: k8s-config
+k8s-config:
+	kubectl create configmap otel-config --from-file=${OTEL_CONFIG_FILE} -n ${OTEL_NAMESPACE} --save-config
+
+.PHONY: k8s-config-update
+k8s-config-update:
+	kubectl create configmap otel-config --from-file=${OTEL_CONFIG_FILE} -n ${OTEL_NAMESPACE} --dry-run=client -o yaml | kubectl apply -f -

--- a/README.md
+++ b/README.md
@@ -127,8 +127,19 @@ your desired [configuration](https://opentelemetry.io/docs/collector/configurati
 from it in the namespace you created above:
 
 ```
-kubectl create configmap otel-config --from-file=./otel-config.yaml -n $OTEL_NAMESPACE
+make k8s-config
 ```
+
+(You can point this to a different config file by setting the `OTEL_CONFIG_FILE` environment variable)
+
+To make changes to the OTel ConfigMap, edit your local config file and run:
+
+```
+make k8s-config-update
+```
+
+Note, if the collector pod is already running, it will need to be restarted to pick up any changes
+to the config (this can be done by simply deleting the pod).
 
 ### Build a container image
 


### PR DESCRIPTION
This is more for the "updating" workflow, to make it easier to make changes to the config in the cluster.

Maybe this is overkill, but I felt like the weird `kubectl --dry-run | kubectl apply` command might be easier for new users to just abstract away