### PR TITLE
Add redaction example

### DIFF
--- a/build/cloudbuild/builder-config.yaml
+++ b/build/cloudbuild/builder-config.yaml
@@ -25,6 +25,8 @@ receivers:
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.57.2
+  - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.57.2
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
     gomod: go.opentelemetry.io/collector v0.57.2
   - import: go.opentelemetry.io/collector/processor/batchprocessor

--- a/build/local/builder-config.yaml
+++ b/build/local/builder-config.yaml
@@ -25,6 +25,8 @@ receivers:
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
     gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.57.2
+  - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.57.2
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
     gomod: go.opentelemetry.io/collector v0.57.2
   - import: go.opentelemetry.io/collector/processor/batchprocessor

--- a/deploy/gke/redaction/Makefile
+++ b/deploy/gke/redaction/Makefile
@@ -1,0 +1,15 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include ../../../Makefile

--- a/deploy/gke/redaction/README.md
+++ b/deploy/gke/redaction/README.md
@@ -1,4 +1,6 @@
-## Running a simple collector deployment on GKE
+## Redacting span attributes with the OpenTelemetry collector
+
+This is a GKE-specific guide for using the collector's [redaction processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor#redaction-processor). See the upstream documentation for the config reference.
 
 If this is the first example you are trying out, follow the [Setup](../setup.md) instructions to
 complete the prerequisites.
@@ -14,7 +16,7 @@ export OTEL_NAMESPACE=otel-collector
 kubectl create namespace $OTEL_NAMESPACE
 ```
 
-### Create ConfigMap
+### Create ConfigMaps
 
 The [`otel-config.yaml`](otel-config.yaml) file contains a sample OpenTelemetry Collector config that is
 prepopulated with some of the receivers, exporters, and processors included in this project. Edit it to
@@ -22,6 +24,7 @@ your desired [configuration](https://opentelemetry.io/docs/collector/configurati
 from it in the namespace you created above:
 
 ```
+cd deploy/gke/redaction/
 kubectl create configmap otel-config --from-file=./otel-config.yaml -n $OTEL_NAMESPACE
 ```
 
@@ -31,7 +34,6 @@ When you built your collector image, the file [`manifest.yaml`](manifest.yaml)
 was automatically updated to reference your image name. Create this manifest in your cluster with:
 
 ```
-cd deploy/gke/simple/
 kubectl apply -f manifest.yaml -n $OTEL_NAMESPACE
 ```
 

--- a/deploy/gke/redaction/README.md
+++ b/deploy/gke/redaction/README.md
@@ -30,8 +30,7 @@ kubectl create configmap otel-config --from-file=./otel-config.yaml -n $OTEL_NAM
 
 ### Create the Deployment
 
-When you built your collector image, the file [`manifest.yaml`](manifest.yaml)
-was automatically updated to reference your image name. Create this manifest in your cluster with:
+Create this manifest in your cluster with:
 
 ```
 kubectl apply -f manifest.yaml -n $OTEL_NAMESPACE

--- a/deploy/gke/redaction/manifest.yaml
+++ b/deploy/gke/redaction/manifest.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: otel-collector
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  ports:
+  - name: otlp-grpc # Default endpoint for OpenTelemetry gRPC receiver.
+    port: 4317
+    protocol: TCP
+    targetPort: 4317
+  selector:
+    component: otel-collector
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+  labels:
+    app: opentelemetry
+    component: otel-collector
+spec:
+  selector:
+    matchLabels:
+      app: opentelemetry
+      component: otel-collector
+  minReadySeconds: 5
+  progressDeadlineSeconds: 120
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: opentelemetry
+        component: otel-collector
+    spec:
+      containers:
+      - command:
+          - "/otelcol-custom"
+          - "--config=/conf/otel-config.yaml"
+        image: %OTEL_COLLECTOR_IMAGE%
+        name: otel-collector
+        resources:
+          limits:
+            cpu: 1
+            memory: 2Gi
+          requests:
+            cpu: 200m
+            memory: 400Mi
+        ports:
+        - containerPort: 4317 # default OTLP receiver
+        - containerPort: 55678 # opencensus (tracing) receiver
+        - containerPort: 55679 # zpages
+        volumeMounts:
+        - name: otel-collector-config-vol
+          mountPath: /conf
+        - name: testdata
+          mountPath: /testdata
+      serviceAccountName: otel-collector
+      volumes:
+        - configMap:
+            name: otel-config
+          name: otel-collector-config-vol
+        - configMap:
+            name: testdata
+          name: testdata

--- a/deploy/gke/redaction/otel-config.yaml
+++ b/deploy/gke/redaction/otel-config.yaml
@@ -1,0 +1,64 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  # The googlecloud exporter sends traces to google cloud trace.
+  googlecloud:
+    retry_on_failure:
+      enabled: false
+
+  # The logging exporter writes telemetry to stdout.
+  logging:
+    loglevel: debug
+
+processors:
+  # The resourcedetection processor can detect information about our GKE cluster.
+  resourcedetection/gke:
+    detectors: [env, gke]
+    timeout: 2s
+    override: false
+
+  # The memory limiter processor can drop telemetry to prevent running out of memory
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 65
+    spike_limit_percentage: 20
+  # The batch processor groups your telemetry together to prevent running out of google cloud API request quota.
+  batch:
+    send_batch_max_size: 200
+    send_batch_size: 200
+
+  # The redaction processor can mask span attribute values that you don't want to export.
+  redaction/credit_cards:
+    allow_all_keys: true
+    # blocked_values is a list of regular expressions for blocking values of
+    # allowed span attributes. Values that match are masked
+    blocked_values:
+      - "4[0-9]{12}(?:[0-9]{3})?" ## Visa credit card number
+      - "(5[1-5][0-9]{14})"       ## MasterCard number
+    summary: silent
+
+service:
+  pipelines:
+    # This sample sets up a pipeline for traces.  It includes the redaction/credit_cards to mask credit cards.
+    traces:
+      receivers: [otlp, otlpjsonfile/testdata]
+      processors: [memory_limiter, batch, resourcedetection/gke, redaction/credit_cards]
+      exporters: [googlecloud, logging]

--- a/deploy/gke/setup.md
+++ b/deploy/gke/setup.md
@@ -1,0 +1,10 @@
+
+## Setup
+
+* A built and pushed collector container image.  See [Building a Collector Image Locally](../../../build/local/) for instructions for a local build.
+* A GCP project with billing enabled
+* A running GKE cluster
+* Artifact Registry enabled in your GCP project
+* Cloud Metrics, Cloud Trace, and/or Cloud Logging APIs enabled (optional depending on exporters configured in your collector)
+
+Note that you may also need to configure certain GCP service account permissions.

--- a/deploy/gke/simple/README.md
+++ b/deploy/gke/simple/README.md
@@ -22,16 +22,15 @@ your desired [configuration](https://opentelemetry.io/docs/collector/configurati
 from it in the namespace you created above:
 
 ```
+cd deploy/gke/simple/
 kubectl create configmap otel-config --from-file=./otel-config.yaml -n $OTEL_NAMESPACE
 ```
 
 ### Create the Deployment
 
-When you built your collector image, the file [`manifest.yaml`](manifest.yaml)
-was automatically updated to reference your image name. Create this manifest in your cluster with:
+Create this manifest in your cluster with:
 
 ```
-cd deploy/gke/simple/
 kubectl apply -f manifest.yaml -n $OTEL_NAMESPACE
 ```
 


### PR DESCRIPTION
This example shows how to use the redaction processor to remove credit card numbers.  It is based on the example config used in the redaction processor documentation: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/redactionprocessor.  It uses the otlpjsonfile receiver to generate an input span to show how the feature works.

I removed the try it out section as the json file receiver doesn't appear to work at all...