### PR TITLE
Update instructions in README

### DIFF
--- a/build/local/Makefile
+++ b/build/local/Makefile
@@ -16,6 +16,7 @@ include ../../Makefile
 
 OUTPUT_DIR=bin
 OTEL_VERSION=0.57.2
+GCLOUD_PROJECT ?= $(shell gcloud config get project)
 
 .PHONY: setup
 setup:

--- a/build/local/README.md
+++ b/build/local/README.md
@@ -1,3 +1,13 @@
+## Prerequisites 
+Prior to following the instructions here, make sure of the following steps to ensure a smooth process - 
+ - You should have `go` installed on your machine. You can find the installation instructions for your OS [here](https://go.dev/doc/install). 
+    - Verify the installation by running `go version`.
+    - Add the path to go's installation `bin` folder to your PATH variable. Instructions to do this are also mentioned on the go installation instructions page.  
+ - Make sure that you have [docker](https://docs.docker.com/engine/install/) installed on your machine.
+    - Also verify that you are able to run docker commands without the need to gain root permissions using sudo. You can follow the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) to achieve this.
+    - To verify that the post-installation steps have been completed successfully and that you can run docker without the need for using `sudo`, try running `docker run hello-world`. This command should run successfully now. 
+
+
 ## Building a Collector Binary locally
 
 To build a local collector binary run:
@@ -8,12 +18,15 @@ make build
 
 ## Build a Collector Docker container locally 
 
+At the end of these steps, you should have a docker image with the collector generated within the `bin` folder. 
+
 ### Prerequisite: Setup an Artifact Registry
 
 To setup your artifact registry, run:
 ```
 make setup-artifact-registry
 ```
+This will create an artifact registry with the name `otel-collectors` within your selected Google Cloud project. The name can be changed by updating the `CONTAINER_REGISTRY` variable as explained [here](#customizable-settings).
 
 ### Build a Docker Container image locally
 
@@ -23,19 +36,25 @@ Build a docker image with:
 make docker-build
 ```
 
-### Push your Docker Container Image to the Artifact Registry
+## Push your Docker Container Image to the [Artifact Registry](https://cloud.google.com/artifact-registry)
 
-Set `$GCLOUD_PROJECT` and `$CONTAINER_REGISTRY` to tag and push the resulting image.
-Note: you will need an existing registry for this to work, that can be created with ``.
+Set `$GCLOUD_PROJECT` with the name of your Google Cloud project to tag and push the resulting image.
+Note: you will need an existing registry for this to work, that was created as part of the [prequisites](#prerequisite-setup-an-artifact-registry).
 
 ```
-export GCLOUD_PROJECT=my-gcp-project
-export CONTAINER_REGISTRY=custom-collectors
+export GCLOUD_PROJECT=<name of you GCP project>
 make docker-push
 ```
 
-(If you get a permission error, you may need to run `gcloud auth configure-docker <your-registry-location>` to authenticate
-Docker against your container registry).
+#### NOTE:
+ - If you get a permission error, you may need to run `gcloud auth configure-docker <your-artifact-registry>` to authenticate Docker against your artifact registry. 
+ - Here, `<your-artifact-registry>` would look something like `us-central1-docker.pkg.dev` if your preferred location for your created registry was `us-central1`. 
+    - You can get a list of valid locations by running `gcloud artifacts locations list`.
+ - The preferred location can be modified by updating the Makefile ([explained below](#Customizable-settings)).
+ - If you are unsure about what should be `<your-artifact-registry>`, you can also find the exact command to run from Google Cloud console. Navigate to the Artifact Registry product page within your selected project, select the artifact registry you created and click **Setup Instructions** button. The popup should have the exact  command that you need to run to authenticate docker. 
+
+
+#### Customizable settings  
 
 You can customize these build steps by setting the following environment variables defined in the [Makefile](../../Makefile):
 

--- a/build/local/README.md
+++ b/build/local/README.md
@@ -1,12 +1,8 @@
 ## Prerequisites 
 Prior to following the instructions here, make sure of the following steps to ensure a smooth process - 
- - You should have `go` installed on your machine. You can find the installation instructions for your OS [here](https://go.dev/doc/install). 
-    - Verify the installation by running `go version`.
-    - Add the path to go's installation `bin` folder to your PATH variable. Instructions to do this are also mentioned on the go installation instructions page.  
+ - You should have `go` installed on your machine. You can find the installation instructions for your OS [here](https://go.dev/doc/install).
  - Make sure that you have [docker](https://docs.docker.com/engine/install/) installed on your machine.
     - Also verify that you are able to run docker commands without the need to gain root permissions using sudo. You can follow the [post-installation steps](https://docs.docker.com/engine/install/linux-postinstall/) to achieve this.
-    - To verify that the post-installation steps have been completed successfully and that you can run docker without the need for using `sudo`, try running `docker run hello-world`. This command should run successfully now. 
-
 
 ## Building a Collector Binary locally
 
@@ -28,6 +24,8 @@ make setup-artifact-registry
 ```
 This will create an artifact registry with the name `otel-collectors` within your selected Google Cloud project. The name can be changed by updating the `CONTAINER_REGISTRY` variable as explained [here](#customizable-settings).
 
+*You can view the currently selected project by running `gcloud config get project` in a terminal.*
+
 ### Build a Docker Container image locally
 
 Build a docker image with:
@@ -38,11 +36,9 @@ make docker-build
 
 ## Push your Docker Container Image to the [Artifact Registry](https://cloud.google.com/artifact-registry)
 
-Set `$GCLOUD_PROJECT` with the name of your Google Cloud project to tag and push the resulting image.
 Note: you will need an existing registry for this to work, that was created as part of the [prequisites](#prerequisite-setup-an-artifact-registry).
 
 ```
-export GCLOUD_PROJECT=<name of you GCP project>
 make docker-push
 ```
 

--- a/build/local/README.md
+++ b/build/local/README.md
@@ -49,7 +49,6 @@ make docker-push
  - The preferred location can be modified by updating the Makefile ([explained below](#Customizable-settings)).
  - If you are unsure about what should be `<your-artifact-registry>`, you can also find the exact command to run from Google Cloud console. Navigate to the Artifact Registry product page within your selected project, select the artifact registry you created and click **Setup Instructions** button. The popup should have the exact  command that you need to run to authenticate docker. 
 
-
 #### Customizable settings  
 
 You can customize these build steps by setting the following environment variables defined in the [Makefile](../../Makefile):


### PR DESCRIPTION
While following the instructions in the README file for the local build for collector builder sample, I encountered a few issues which I have documented here. 
I believe the changes made to the README in this PR would help alleviate some of these concerns and the doc would be more clear. 

 - The instructions did not mention the prerequisite requirement of having go installed and go’s bin folder to be on the path variable. This issue resulted in the `make build` command failing. 

 - The instructions mention setting `CONTAINER_REGISTRY` as an environment variable. This variable is already set within the root makefile and should be set there. The `GCLOUD_PROJECT` environment variable should be set. 

 - The readme mentioned a possibility of running into permissions issues with gcloud and suggested the correct command, but the command took some time figuring out. There should be an example there. The correct command can be retrieved from the google cloud console. 

 - The example requires docker to be able to run without explicitly running using sudo. Basically, `docker run hello-world` should be able to run. Otherwise it leads to some other permissions issues. 
