### PR TITLE
Use gcp resource detector instead of deprecated gke detector

### DIFF
--- a/deploy/gke/redaction/otel-config.yaml
+++ b/deploy/gke/redaction/otel-config.yaml
@@ -31,7 +31,7 @@ exporters:
 processors:
   # The resourcedetection processor can detect information about our GKE cluster.
   resourcedetection/gke:
-    detectors: [env, gke]
+    detectors: [env, gcp]
     timeout: 2s
     override: false
 

--- a/deploy/gke/simple/otel-config.yaml
+++ b/deploy/gke/simple/otel-config.yaml
@@ -74,7 +74,7 @@ exporters:
 
 processors:
   resourcedetection/gke:
-    detectors: [env, gke]
+    detectors: [env, gcp]
     timeout: 2s
     override: false
 


### PR DESCRIPTION
This will fix a warning that is printed on startup.