### PR TITLE
Memory limiter seems to require check_interval as an argument

### DIFF
--- a/deploy/gke/simple/otel-config.yaml
+++ b/deploy/gke/simple/otel-config.yaml
@@ -79,6 +79,9 @@ processors:
     override: false
 
   memory_limiter:
+    check_interval: 1s
+    limit_percentage: 65
+    spike_limit_percentage: 20
   batch:
     send_batch_max_size: 200
     send_batch_size: 200


### PR DESCRIPTION
I fixed this in the redaction example, but forgot to apply it to the simple example.