### PR TITLE
Update sed command to use fully qualified docker image location

### DIFF
--- a/build/local/Makefile
+++ b/build/local/Makefile
@@ -30,7 +30,7 @@ build: setup
 .PHONY: docker-build
 docker-build: setup
 	docker build -t ${IMAGE_NAME}:${IMAGE_VERSION} .
-	sed -i "s/%OTEL_COLLECTOR_IMAGE%/${IMAGE_NAME}:${IMAGE_VERSION}/g" ../../deploy/gke/simple/manifest.yaml
+	sed -i "s/%OTEL_COLLECTOR_IMAGE%/${REGISTRY_LOCATION}-docker.pkg.dev\/${GCLOUD_PROJECT}\/${CONTAINER_REGISTRY}\/${IMAGE_NAME}:${IMAGE_VERSION}/g" ../../deploy/gke/simple/manifest.yaml
 
 .PHONY: docker-push
 docker-push:

--- a/deploy/gke/simple/manifest.yaml
+++ b/deploy/gke/simple/manifest.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1:
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: otel-collector


### PR DESCRIPTION
### Issue - Failed to pull image 
The sed command used in the `local/build/Makefile`'s `docker-build` target that replaces the generated docker image name in `manifest.yaml` for the kubernetes deployment for the samples does not give the full path for the image. 

Since the image does not use fully qualified path, at runtime the docker registry is inferred as `docker.io`. This results in the pod trying to fetch for a docker image at - `docker.io/library/otelcol-custom:latest` which is not found. 

### Fix
 - This PR updates the sed command so that it replaces the image location with the fully qualified path.
 
 
### Testing 
 This change was manually tested by verifying that the Image location in the manifest.yaml is updated with the expected location when `docker-build` target is run as procedure of building the collector image locally. (*Steps to build the image locally are defined [in the build folder of this repository](https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/tree/main/build/local)*)