### PR TITLE
Update documentation for simple sample run

### DIFF
--- a/deploy/gke/setup.md
+++ b/deploy/gke/setup.md
@@ -1,10 +1,13 @@
 
 ## Setup
 
-* A built and pushed collector container image.  See [Building a Collector Image Locally](../../build/local/) for instructions for a local build.
-* A GCP project with billing enabled
+* A built and pushed collector container image.  See [Building a Collector Image Locally](../../build/local/README.md) for instructions for a local build.
+* A GCP project with billing enabled.
 * A running GKE cluster
-* Artifact Registry enabled in your GCP project
-* Cloud Metrics, Cloud Trace, and/or Cloud Logging APIs enabled (optional depending on exporters configured in your collector)
+    - GKE offers 2 kinds of clusters - [Autopilot](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-an-autopilot-cluster) and [Standard](https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters). These sample should work with both kinds of clusters. 
+    - After creating the clusters, you will have to connect your local command line to the created cluster in order to interact with it. The steps to do this are available on your cloud console. 
+        - On Google Cloud Console, locate & click the cluster you just created, on the resulting details page, there will be a `Connect` button on the top of the page containing the instructions to configure the cluster for local command line access. *(You should have `kubectl` installed for this)*
+* Artifact Registry API enabled in your GCP project.
+* Cloud Metrics, Cloud Trace, and/or Cloud Logging APIs enabled (optional depending on exporters configured in your collector).
 
 Note that you may also need to configure certain GCP service account permissions.

--- a/deploy/gke/setup.md
+++ b/deploy/gke/setup.md
@@ -1,12 +1,15 @@
 
+## Prerequisites
+Running the GKE (Google Kubernetes Engine) samples in this repository assumes familiarity with the following - 
+ - Creating GKE clusters on Google Cloud. 
+ - Configuring command-line access to your cluster via kubectl. 
+
+For more information on these, you can checkout [Create a GKE cluster](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-an-autopilot-cluster) & [Configure cluster access](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#gcloud_1).  
 ## Setup
 
 * A built and pushed collector container image.  See [Building a Collector Image Locally](../../build/local/README.md) for instructions for a local build.
 * A GCP project with billing enabled.
-* A running GKE cluster
-    - GKE offers 2 kinds of clusters - [Autopilot](https://cloud.google.com/kubernetes-engine/docs/how-to/creating-an-autopilot-cluster) and [Standard](https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters). These sample should work with both kinds of clusters. 
-    - After creating the clusters, you will have to connect your local command line to the created cluster in order to interact with it. The steps to do this are available on your cloud console. 
-        - On Google Cloud Console, locate & click the cluster you just created, on the resulting details page, there will be a `Connect` button on the top of the page containing the instructions to configure the cluster for local command line access. *(You should have `kubectl` installed for this)*
+* A running GKE cluster with command line access configured.     
 * Artifact Registry API enabled in your GCP project.
 * Cloud Metrics, Cloud Trace, and/or Cloud Logging APIs enabled (optional depending on exporters configured in your collector).
 

--- a/deploy/gke/simple/README.md
+++ b/deploy/gke/simple/README.md
@@ -3,7 +3,11 @@
 If this is the first example you are trying out, follow the [Setup](../setup.md) instructions to
 complete the prerequisites.
 
-See the [Troubleshooting](../troubleshooting.md) guide for more information if you encounter issues.
+**NOTE:** As a reminder, if you completed the pre-requisite steps successfully, the following requirements should have already been met - 
+ - You should see the image name in [manifest.yaml](./manifest.yaml) updated with the fully qualified docker image name. 
+ - The above mentioned docker image is actually uploaded to Artifact Registry and is visible there in cloud console.
+
+If the above requirements are not met, please ensure that all the [Setup](../setup.md) instructions have been followed. You may need to perform a [local build](../../../build/local/README.md) again.
 
 ### Set up namespace
 
@@ -33,6 +37,38 @@ Create this manifest in your cluster with:
 ```
 kubectl apply -f manifest.yaml -n $OTEL_NAMESPACE
 ```
+
+### Verify the Deployment
+
+After creating the deployment, you should verify that all pods created as part of the deployment are **running** - 
+
+```
+kubectl get deployments -n $OTEL_NAMESPACE
+``` 
+
+If the pods are not running, try using `kubectl describe` on the failing pods to get the exact cause for failure.
+
+You can also use `kubectl logs` to check the logs of the failing pod containers to pinpoint the cause. 
+
+The [Troubleshooting](../troubleshooting.md) guide for more information on some of the most common issues such as authentication related issues. 
+
+### Expected Outcome after Running this Sample
+
+After a successful deployment of this sample, what we have is a GKE cluster on which we have a OpenTelemetry collector running. The collector is configured using the [otel-config](./otel-config.yaml) file. 
+
+Since there is no application currently running on the cluster, the collector is not recieving any telemetry data. The current configuration in the [otel-config](./otel-config.yaml) file does however, scrape the collector itself for some metrics *(See the `prometheus/self` declared under `receivers`)* and exports these to stdout and google cloud. 
+
+ - To check for metrics being exported to stdout, run `kubectl logs <pod_name> -n $OTEL_NAMESPACE`.
+ - To check for metrics being exported to google cloud, open Metrics Explorer in Google Cloud Console. 
+
+ There are many metrics that are emitted from the OpenTelemetry collector itself and most of these metrics start with the prefix `Otelcol` and you can search for this string in metrics explorer. 
+
+#### Potential Issues 
+If you are not seeing metrics on Google Cloud, first run `kubectl logs <pod_name> -n $OTEL_NAMESPACE` to verify that they are being printed locally within the pod container and if any error/issue is being reported while exporting metrics to Google Cloud. 
+
+Most likely, this issue is due to permission errors. Try following the troubleshooting steps mentioned here - [Permission errors exporting telemetry](../troubleshooting.md#permission-errors-exporting-telemetry).
+
+*NOTE: You can chnage the configuration for the OpenTelemetry Collector to alter its behaviour.*
 
 ### (Optional) Cleanup
 

--- a/deploy/gke/simple/README.md
+++ b/deploy/gke/simple/README.md
@@ -50,7 +50,7 @@ If the pods are not running, try using `kubectl describe` on the failing pods to
 
 You can also use `kubectl logs` to check the logs of the failing pod containers to pinpoint the cause. 
 
-The [Troubleshooting](../troubleshooting.md) guide for more information on some of the most common issues such as authentication related issues. 
+The [troubleshooting](../troubleshooting.md) guide for more information on some of the most common issues such as authentication related issues. 
 
 ### Expected Outcome after Running this Sample
 
@@ -63,12 +63,9 @@ Since there is no application currently running on the cluster, the collector is
 
  There are many metrics that are emitted from the OpenTelemetry collector itself and most of these metrics start with the prefix `Otelcol` and you can search for this string in metrics explorer. 
 
-#### Potential Issues 
-If you are not seeing metrics on Google Cloud, first run `kubectl logs <pod_name> -n $OTEL_NAMESPACE` to verify that they are being printed locally within the pod container and if any error/issue is being reported while exporting metrics to Google Cloud. 
-
-Most likely, this issue is due to permission errors. Try following the troubleshooting steps mentioned here - [Permission errors exporting telemetry](../troubleshooting.md#permission-errors-exporting-telemetry).
-
 *NOTE: You can chnage the configuration for the OpenTelemetry Collector to alter its behaviour.*
+
+In case you are not seeing the expected outcome or are running into errors, look at the [troubleshooting](../troubleshooting.md) guide for more information.
 
 ### (Optional) Cleanup
 

--- a/deploy/gke/troubleshooting.md
+++ b/deploy/gke/troubleshooting.md
@@ -14,10 +14,12 @@ to identify it as the Workload Identity account.
 If you don't already have one, create a GCP service account to authorize the collector to send metrics, traces, and logs:
 
 ```
-export GCLOUD_PROJECT=<your GCP project>
+export GCLOUD_PROJECT=<the project ID of the Google Cloud project of your IAM service account>
 export PROJECT_ID=<your Google Cloud project ID>
 gcloud iam service-accounts create otel-collector --project=${GCLOUD_PROJECT}
 ```
+
+**NOTE:** *If your GKE cluster and your service account are created in the same GCP project, then `GCLOUD_PROJECT` & `PROJECT_ID` will be the same.*
 
 Give the service account access to write metrics, traces, and logs (or more/fewer roles based on your config):
 
@@ -52,8 +54,16 @@ kubectl annotate serviceaccount otel-collector \
     iam.gke.io/gcp-service-account=GSA_NAME@GSA_PROJECT.iam.gserviceaccount.com
 ```
 
+In the above,
+- GSA_NAME: the name of your IAM service account.
+- GSA_PROJECT: this is the GCP project to which the IAM service account belongs.
+
+Essetially, `iam.gke.io/gcp-service-account` should contain the email of the service account you created using `gcloud iam service-accounts create` command in the beginning.
+
+*Note that most of the steps in the above link to GCP documentation, like **creating a new namespace** would have already been done as part of running this sample (We will be using the same `$OTEL_NAMESPACE`).*
+
 Following this, the collector pod will need to be restarted to take advantage of the new permissions.
-You can do this by simply deleting it with `kubectl delete pod/otel-collector-<POD_NAME>`.
+You can do this by simply deleting it with `kubectl delete pod/otel-collector-<POD_NAME> -n $OTEL_NAMESPACE`.
 
 #### (Cleanup) Remove gcloud service account and bindings
 ```
@@ -100,6 +110,7 @@ For example, if you are using `gcr.io` in `us` with the account from above:
 ```
 gcloud artifacts repositories add-iam-policy-binding gcr.io \
     --location=us \
-    --member=123456789123-compute@developer.gserviceaccount.com \
+    --member=serviceAccount:123456789123-compute@developer.gserviceaccount.com \
     --role="roles/artifactregistry.reader"
 ```
+NOTE: If you followed the **default values** in this sample and are using Artifact Registry, `gcr.io` should be replaced with `otel-collectors` *(name of the repository)* and `us` would be `us-central1` *(location of the repository)*.

--- a/deploy/gke/troubleshooting.md
+++ b/deploy/gke/troubleshooting.md
@@ -1,5 +1,13 @@
 ## Troubleshooting deployment on GKE
 
+### Cluster running but not seeing metrics on Google Cloud Console
+
+If your cluster deployment is working fine, meaning all your pods are in a running state and `kubectl describe` does not show any issues, you can try running un `kubectl logs <pod_name> -n $OTEL_NAMESPACE` to figure out the exact cause for telemetry data not being exported to Google Cloud. 
+
+Running this command will also show you if the telemetry data is being printed locally within the pod container. If not, then there might be an issue with the OpenTelemetry Collector configuration. This is likely if you udpated/modified the collector configuration. 
+
+If the telemetry data is being printed locally, then most likely it is a permissions issue. You can verify this by looking at the errors within the logs. If this is the case, try following the steps mentioned in the below section - [Permission errors exporting telemetry](#permission-errors-exporting-telemetry).
+
 ### Permission errors exporting telemetry
 
 If the collector pod fails to export metrics/logs/traces to GCP, it may need to be authorized
@@ -14,7 +22,7 @@ to identify it as the Workload Identity account.
 If you don't already have one, create a GCP service account to authorize the collector to send metrics, traces, and logs:
 
 ```
-export GCLOUD_PROJECT=<the project ID of the Google Cloud project of your IAM service account>
+export GCLOUD_PROJECT=<the Google Cloud project ID to which your IAM service account belongs>
 export PROJECT_ID=<your Google Cloud project ID>
 gcloud iam service-accounts create otel-collector --project=${GCLOUD_PROJECT}
 ```


### PR DESCRIPTION
### Issue - Instructions to run 'Simple' sample needed a little more clarity

 - Following the instructions to create a GKE cluster and run OTel collector needed a little more clarity from the perspective of a new user with less knowledge of kubernetes. 
 - What was the expected outcome as a result of following this sample as-is was also unclear. 

### Fix 
 - This PR attempts to add more clarity to the instructions for running the sample by being more explicit.  

### Testing 
 - Was able to re-run the sample with relative ease following these instructions (Started from a clean-slate). 
