### PR TITLE
Update samples to latest build

### DIFF
--- a/build/cloudbuild-automation/Dockerfile
+++ b/build/cloudbuild-automation/Dockerfile
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 as build
-ARG  OTEL_VERSION=0.57.2
+FROM golang:1.19 as build
+ARG  OTEL_VERSION=0.75.0
 WORKDIR /app
 COPY . .
 RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
-RUN builder --config=builder-config.yaml --name=otelcol-custom --output-path=.
+RUN builder --config=builder-config.yaml
 
 FROM gcr.io/distroless/base-debian11
-COPY --from=build /app/otelcol-custom /
+COPY --from=build /app/bin/otelcol-custom /
 # 4317 - default OTLP receiver
 # 55678 - opencensus (tracing) receiver
 # 55679 - zpages

--- a/build/cloudbuild-automation/builder-config.yaml
+++ b/build/cloudbuild-automation/builder-config.yaml
@@ -12,34 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+dist:
+  name: otelcol-custom
+  output_path: ./bin
+
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0
+    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.75.0
 
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.75.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0
+    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.75.0
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.70.0
+    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.75.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0
+    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.75.0

--- a/build/cloudbuild/Dockerfile
+++ b/build/cloudbuild/Dockerfile
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 as build
-ARG  OTEL_VERSION=0.57.2
+FROM golang:1.19 as build
+ARG  OTEL_VERSION=0.75.0
 WORKDIR /app
 COPY . .
 RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
-RUN builder --config=builder-config.yaml --name=otelcol-custom --output-path=.
+RUN builder --config=builder-config.yaml
 
 FROM gcr.io/distroless/base-debian11
-COPY --from=build /app/otelcol-custom /
+COPY --from=build /app/bin/otelcol-custom /
 # 4317 - default OTLP receiver
 # 55678 - opencensus (tracing) receiver
 # 55679 - zpages

--- a/build/cloudbuild/builder-config.yaml
+++ b/build/cloudbuild/builder-config.yaml
@@ -12,34 +12,38 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+dist:
+  name: otelcol-custom
+  output_path: ./bin
+
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0
+    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.75.0
 
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.75.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0
+    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.75.0
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.70.0
+    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.75.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0
+    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.75.0

--- a/build/local/Dockerfile
+++ b/build/local/Dockerfile
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.18 as build
-ARG  OTEL_VERSION=0.57.2
+FROM golang:1.19 as build
+ARG  OTEL_VERSION=0.75.0
 WORKDIR /app
 COPY . .
 RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
-RUN builder --config=builder-config.yaml --name=otelcol-custom --output-path=.
+RUN builder --config=builder-config.yaml
 
 FROM gcr.io/distroless/base-debian11
-COPY --from=build /app/otelcol-custom /
+COPY --from=build /app/bin/otelcol-custom /
 # 4317 - default OTLP receiver
 # 55678 - opencensus (tracing) receiver
 # 55679 - zpages

--- a/build/local/Makefile
+++ b/build/local/Makefile
@@ -25,7 +25,7 @@ setup:
 .PHONY: build
 build: setup
 	mkdir -p ${OUTPUT_DIR}
-	builder --config=builder-config.yaml --name=otelcol-custom --output-path=${OUTPUT_DIR}/.
+	builder --config=builder-config.yaml
 
 .PHONY: docker-build
 docker-build: setup

--- a/build/local/Makefile
+++ b/build/local/Makefile
@@ -15,7 +15,7 @@
 include ../../Makefile
 
 OUTPUT_DIR=bin
-OTEL_VERSION=0.70.0
+OTEL_VERSION=0.75.0
 GCLOUD_PROJECT ?= $(shell gcloud config get project)
 
 .PHONY: setup

--- a/build/local/builder-config.yaml
+++ b/build/local/builder-config.yaml
@@ -18,32 +18,32 @@ dist:
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0
+    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.75.0
 
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.75.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.70.0
+    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.75.0
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.70.0
+    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.75.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.70.0
+    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.75.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.70.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.75.0

--- a/build/local/builder-config.yaml
+++ b/build/local/builder-config.yaml
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+dist:
+  name: otelcol-custom
+  output_path: ./bin
+
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
     gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.70.0

--- a/deploy/gke/simple/otel-config.yaml
+++ b/deploy/gke/simple/otel-config.yaml
@@ -57,6 +57,8 @@ receivers:
           action: labeldrop
         - regex: service_version
           action: labeldrop
+        - regex: service_name
+          action: labeldrop
 
 exporters:
   googlecloud:


### PR DESCRIPTION
Fixes #37 
Updates build samples to latest collector image and Golang version. Also removes deprecated flags warnings by updating collector-builder configs to use `dist` blocks

Tested local build and cloud build both compile. Ran cloud build image on a gke cluster and fixed one error in config.