### PR TITLE
Update to go1.21, collector v0.86.0, and disable CGO

### DIFF
--- a/build/cloudbuild-automation/Dockerfile
+++ b/build/cloudbuild-automation/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 as build
-ARG  OTEL_VERSION=0.75.0
+FROM golang:1.21 as build
+ARG  OTEL_VERSION=0.86.0
 WORKDIR /app
 COPY . .
 RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
-RUN builder --config=builder-config.yaml
+RUN CGO_ENABLED=0 builder --config=builder-config.yaml
 
 FROM gcr.io/distroless/base-debian11
 COPY --from=build /app/bin/otelcol-custom /

--- a/build/cloudbuild-automation/builder-config.yaml
+++ b/build/cloudbuild-automation/builder-config.yaml
@@ -18,32 +18,32 @@ dist:
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.75.0
+    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.86.0
 
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.86.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.75.0
+    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.86.0
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.75.0
+    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.86.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.75.0
+    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.86.0

--- a/build/cloudbuild/Dockerfile
+++ b/build/cloudbuild/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 as build
-ARG  OTEL_VERSION=0.75.0
+FROM golang:1.21 as build
+ARG  OTEL_VERSION=0.86.0
 WORKDIR /app
 COPY . .
 RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
-RUN builder --config=builder-config.yaml
+RUN CGO_ENABLED=0 builder --config=builder-config.yaml
 
 FROM gcr.io/distroless/base-debian11
 COPY --from=build /app/bin/otelcol-custom /

--- a/build/cloudbuild/builder-config.yaml
+++ b/build/cloudbuild/builder-config.yaml
@@ -18,32 +18,32 @@ dist:
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.75.0
+    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.86.0
 
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.86.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.75.0
+    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.86.0
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.75.0
+    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.86.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.75.0
+    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.86.0

--- a/build/local/Dockerfile
+++ b/build/local/Dockerfile
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19 as build
-ARG  OTEL_VERSION=0.75.0
+FROM golang:1.21 as build
+ARG  OTEL_VERSION=0.86.0
 WORKDIR /app
 COPY . .
 RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
-RUN builder --config=builder-config.yaml
+RUN CGO_ENABLED=0 builder --config=builder-config.yaml
 
 FROM gcr.io/distroless/base-debian11
 COPY --from=build /app/bin/otelcol-custom /

--- a/build/local/Makefile
+++ b/build/local/Makefile
@@ -15,7 +15,7 @@
 include ../../Makefile
 
 OUTPUT_DIR=bin
-OTEL_VERSION=0.75.0
+OTEL_VERSION=0.86.0
 GCLOUD_PROJECT ?= $(shell gcloud config get project)
 
 .PHONY: setup
@@ -25,7 +25,7 @@ setup:
 .PHONY: build
 build: setup
 	mkdir -p ${OUTPUT_DIR}
-	builder --config=builder-config.yaml
+	CGO_ENABLED=0 builder --config=builder-config.yaml
 
 .PHONY: docker-build
 docker-build: setup

--- a/build/local/builder-config.yaml
+++ b/build/local/builder-config.yaml
@@ -18,32 +18,32 @@ dist:
 
 receivers:
   - import: go.opentelemetry.io/collector/receiver/otlpreceiver
-    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.75.0
+    gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudpubsubreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otlpjsonfilereceiver v0.86.0
 
 processors:
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.86.0
   - import: go.opentelemetry.io/collector/processor/memorylimiterprocessor
-    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.75.0
+    gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.86.0
   - import: go.opentelemetry.io/collector/processor/batchprocessor
-    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.75.0
+    gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.86.0
 
 exporters:
   - import: go.opentelemetry.io/collector/exporter/loggingexporter
-    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.75.0
+    gomod: go.opentelemetry.io/collector/exporter/loggingexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlemanagedprometheusexporter v0.86.0
   - import: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter
-    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.75.0
+    gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/googlecloudpubsubexporter v0.86.0

--- a/deploy/gke/redaction/otel-config-sample.yaml
+++ b/deploy/gke/redaction/otel-config-sample.yaml
@@ -33,8 +33,6 @@ receivers:
 exporters:
   # The googlecloud exporter sends traces to google cloud trace.
   googlecloud:
-    retry_on_failure:
-      enabled: false
 
   # The logging exporter writes telemetry to stdout.
   logging:

--- a/deploy/gke/redaction/otel-config.yaml
+++ b/deploy/gke/redaction/otel-config.yaml
@@ -21,8 +21,6 @@ receivers:
 exporters:
   # The googlecloud exporter sends traces to google cloud trace.
   googlecloud:
-    retry_on_failure:
-      enabled: false
 
   # The logging exporter writes telemetry to stdout.
   logging:

--- a/deploy/gke/simple/otel-config-sample.yaml
+++ b/deploy/gke/simple/otel-config-sample.yaml
@@ -48,8 +48,6 @@ receivers:
 
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
     log:
       default_log_name: otel-collector-builder-sample/gke-simple-demo # This could be anything
 

--- a/deploy/gke/simple/otel-config.yaml
+++ b/deploy/gke/simple/otel-config.yaml
@@ -62,8 +62,6 @@ receivers:
 
 exporters:
   googlecloud:
-    retry_on_failure:
-      enabled: false
 
   googlemanagedprometheus:
 


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/issues/43

Fixes https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/issues/47

Fixes https://github.com/GoogleCloudPlatform/opentelemetry-collector-builder-sample/issues/46

The retry_on_failure option is removed in recent versions, as the exporter has the correct retry behavior now.